### PR TITLE
fix: add optional chaining

### DIFF
--- a/src/structures/messageCreate.js
+++ b/src/structures/messageCreate.js
@@ -12,15 +12,20 @@ client.on('messageCreate', async (message) => {
     if (afkjson.afkvalue.indexOf(message.author.id) != -1) {
         afkjson.afkvalue.splice(afkjson.afkvalue.indexOf(message.author.id), 1);
         fs.writeFileSync('./src/data/afk.json', JSON.stringify(afkjson));
-        message.member.setNickname(message.author.username)
+        message.member.setNickname(message.author.username);
         message.channel.send(`**\`${message.author.username}\` telah kembali dari AFK!**`);
     }
 
-    let mentioned = message.mentions.members.first();
+    let mentioned = message.mentions.members?.first();
     
     if (mentioned) {
-        if (afkjson.afkvalue.indexOf(mentioned.id) != -1)
-        message.channel.send(`**\`${mentioned.user.username}\` sedang AFK!**`);
+        if (afkjson.afkvalue.indexOf(mentioned.id) != -1) {
+            return message.channel.send(`**\`${mentioned.user.username}\` sedang AFK!**`);
+        } else {
+            return;
+        }
+    } else if (mentioned == null) {
+        return;
     }
 
     if (!message.content.startsWith(prefix) || message.author.bot) return;


### PR DESCRIPTION
## Changes
adding optional chaining to avoid error on first() method
```js
let variable = property?.method();
```

## Status
- [x] Follow the installation from <a href="https://github.com/Muunatic/RyU#how-to-use">**README**</a>.
- [x] Add or edit tests to reflect the change.
- [x] Run npm test.
