### PR TITLE
docs: Remove deprecated Snyk badge

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -6,7 +6,6 @@
 
 <img src="https://img.shields.io/github/repo-size/Muunatic/RyU?style=flat-square">
 <img src="https://img.shields.io/github/package-json/v/Muunatic/RyU?style=flat-square">
-<img src="https://img.shields.io/snyk/vulnerabilities/github/Muunatic/RyU?style=flat-square">
 <img src="https://img.shields.io/github/actions/workflow/status/Muunatic/RyU/ESLint.yml?branch=v5&style=flat-square">
 <img src="https://img.shields.io/github/languages/top/Muunatic/RyU?style=flat-square">
 


### PR DESCRIPTION
## Changes
Snyk badges should show a number of vulnerabilities instead of `'Invalid response data' || 'no longer available'`

## Status

- [x] Follow the installation from <a href="https://github.com/Muunatic/RyU#how-to-use">**README**</a>.
- [x] Add or edit tests to reflect the change.
- [x] Run npm test.