### PR TITLE
chore: Removing unused commands

### DIFF
--- a/src/commands/interaction/help.js
+++ b/src/commands/interaction/help.js
@@ -13,7 +13,7 @@ module.exports = {
         .setTitle('Help commands')
         .setDescription(`Prefix = **${prefix}**`)
         .addFields(
-            { name: 'General command', value: 'ping, time, userinfo, serverinfo, osu, avatar, stats, weather, afk, mal, genshin' },
+            { name: 'General command', value: 'ping, userinfo, serverinfo, osu, avatar, stats, afk, mal, genshin' },
             { name: 'DM command', value: 'report' },
             { name: 'Moderator command', value: 'nickname' },
             { name: 'Admin command', value: 'warn, kick, ban, mute, unmute, user, add, reroll, end, eval'}


### PR DESCRIPTION
## Changes
This list shouldn't be there because it was removed before? @Muunatic 

{ name: 'General command', value: 'ping, _**time**_, userinfo, serverinfo, osu, avatar, stats, _**weather**_, afk, mal, genshin' }
## Status

- [x] Follow the installation from <a href="https://github.com/Muunatic/RyU#how-to-use">**README**</a>.
- [x] Add or edit tests to reflect the change.
- [x] Run npm test.
